### PR TITLE
feat: parse infix operators

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -30,7 +30,7 @@ type Program struct {
 	Statements []Statement
 }
 
-// TokenLiteral returns a string literal value of the statement.
+// TokenLiteral returns a token literal value of the token.
 func (p *Program) TokenLiteral() string {
 	if len(p.Statements) > 0 {
 		return p.Statements[0].TokenLiteral()
@@ -57,7 +57,7 @@ type LetStatement struct {
 	Value Expression
 }
 
-// TokenLiteral returns a string literal value of the token.
+// TokenLiteral returns a token literal value of the token.
 func (ls *LetStatement) TokenLiteral() string { return ls.Token.Literal }
 
 // String returns the string representation of the LetStatement type.
@@ -85,7 +85,7 @@ type ReturnStatement struct {
 	ReturnValue Expression
 }
 
-// TokenLiteral returns a string literal value of the token.
+// TokenLiteral returns a token literal value of the token.
 func (rs *ReturnStatement) TokenLiteral() string { return rs.Token.Literal }
 
 // String returns the string representation of the ReturnStatement type.
@@ -111,7 +111,7 @@ type ExpressionStatement struct {
 	Expression Expression
 }
 
-// TokenLiteral returns a string literal value of the token.
+// TokenLiteral returns a token literal value of the token.
 func (es *ExpressionStatement) TokenLiteral() string { return es.Token.Literal }
 
 // String returns the string representation of the ExpressionStatement type.
@@ -131,7 +131,7 @@ type Identifier struct {
 	Value string
 }
 
-// TokenLiteral returns a string literal value of the token.
+// TokenLiteral returns a token literal value of the token.
 func (i *Identifier) TokenLiteral() string { return i.Token.Literal }
 
 // String returns the Identifier.Value.
@@ -145,10 +145,10 @@ type IntegerLiteral struct {
 	Value int64
 }
 
-// TokenLiteral returns a string literal value of the token.
+// TokenLiteral returns a token literal value of the token.
 func (il *IntegerLiteral) TokenLiteral() string { return il.Token.Literal }
 
-// String returns a string literal value of the token.
+// String returns a string representation of the IntegerLiteral type.
 func (il *IntegerLiteral) String() string { return il.Token.Literal }
 
 func (il *IntegerLiteral) expressionNode() {}
@@ -160,10 +160,10 @@ type PrefixExpression struct {
 	Right    Expression
 }
 
-// TokenLiteral returns a string literal value of the token.
+// TokenLiteral returns a token literal value of the token.
 func (pe *PrefixExpression) TokenLiteral() string { return pe.Token.Literal }
 
-// String returns a string literal value of the token.
+// String returns a string representation of the PrefixExpression type.
 func (pe *PrefixExpression) String() string {
 	var out bytes.Buffer
 
@@ -176,3 +176,29 @@ func (pe *PrefixExpression) String() string {
 }
 
 func (pe *PrefixExpression) expressionNode() {}
+
+// InfixExpression represents an expression such as (4 * 19).
+type InfixExpression struct {
+	Token    token.Token // Refers to Operator token such as (*, +, >)
+	Left     Expression
+	Operator string
+	Right    Expression
+}
+
+// TokenLiteral returns a token literal value of the token.
+func (ie *InfixExpression) TokenLiteral() string { return ie.Token.Literal }
+
+// String returns a string representation of the InfixExpression type.
+func (ie *InfixExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString("(")
+	out.WriteString(ie.Left.String())
+	out.WriteString(" " + ie.Operator + " ")
+	out.WriteString(ie.Right.String())
+	out.WriteString(")")
+
+	return out.String()
+}
+
+func (ie *InfixExpression) expressionNode() {}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mycok/monkey_interpreter/ast"
@@ -21,7 +22,7 @@ func TestParseLetStatements(t *testing.T) {
 	checkParserErrors(t, p)
 
 	if len(program.Statements) != 3 {
-		t.Fatalf("program.Statements expected to contain 3 statements. but got %d", len(program.Statements))
+		t.Fatalf("program.Statements expected to contain 3 statements. but got: %d instead", len(program.Statements))
 	}
 
 	tests := []struct {
@@ -54,19 +55,19 @@ func TestParseReturnStatements(t *testing.T) {
 	checkParserErrors(t, p)
 
 	if len(program.Statements) != 3 {
-		t.Fatalf("program.Statements expected to contain 3 statements. but got %d", len(program.Statements))
+		t.Fatalf("program.Statements expected to contain 3 statements. but got: %d instead", len(program.Statements))
 	}
 
 	for _, stmt := range program.Statements {
 		returnStmt, ok := stmt.(*ast.ReturnStatement)
 
 		if !ok {
-			t.Errorf("stmt is not of a valid *ast.ReturnStatement type. got:%T", stmt)
+			t.Errorf("stmt is not of a valid *ast.ReturnStatement type. got: %T instead", stmt)
 			continue
 		}
 
 		if returnStmt.TokenLiteral() != "return" {
-			t.Errorf("returnStmt.TokenLiteral is not 'return', got:%T", returnStmt.TokenLiteral())
+			t.Errorf("returnStmt.TokenLiteral is not 'return', got: %T instead", returnStmt.TokenLiteral())
 		}
 	}
 }
@@ -81,25 +82,25 @@ func TestParseIdentifierExpressions(t *testing.T) {
 	checkParserErrors(t, p)
 
 	if len(program.Statements) != 1 {
-		t.Fatalf("program.Statements expected to contain 1 statement. but got %d", len(program.Statements))
+		t.Fatalf("program.Statements expected to contain 1 statement. but got: %d instead", len(program.Statements))
 	}
 
 	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
 	if !ok {
-		t.Fatalf("program.Statements[0] is not a valid *ast.ExpressionStatement type. got:%T", program.Statements[0])
+		t.Fatalf("program.Statements[0] is not a valid *ast.ExpressionStatement type. got: %T instead", program.Statements[0])
 	}
 
 	ident, ok := stmt.Expression.(*ast.Identifier)
 	if !ok {
-		t.Fatalf("expression is not a valid *ast.Identifier type. got:%T", stmt.Expression)
+		t.Fatalf("expression is not a valid *ast.Identifier type. got: %T instead", stmt.Expression)
 	}
 
 	if ident.Value != "foobar" {
-		t.Errorf("ident.Value not %s. got:%s", "foobar", ident.Value)
+		t.Errorf("ident.Value not %s. got: %s instead", "foobar", ident.Value)
 	}
 
 	if ident.TokenLiteral() != "foobar" {
-		t.Errorf("ident.TokenLiteral() not %s. got:%s", "foobar", ident.TokenLiteral())
+		t.Errorf("ident.TokenLiteral() not %s. got: %s instead", "foobar", ident.TokenLiteral())
 	}
 
 }
@@ -114,25 +115,25 @@ func TestParseIntegerLiteralExpressions(t *testing.T) {
 	checkParserErrors(t, p)
 
 	if len(program.Statements) != 1 {
-		t.Fatalf("program.Statement expected to contain 1 statement. but got %d", len(program.Statements))
+		t.Fatalf("program.Statement expected to contain 1 statement. but got: %d instead", len(program.Statements))
 	}
 
 	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
 	if !ok {
-		t.Fatalf("program.Statements[0] is not a valid *ast.ExpressionStatement type. got:%T", program.Statements[0])
+		t.Fatalf("program.Statements[0] is not a valid *ast.ExpressionStatement type. got: %T instead", program.Statements[0])
 	}
 
 	literal, ok := stmt.Expression.(*ast.IntegerLiteral)
 	if !ok {
-		t.Fatalf("expression is not a valid *ast.Identifier type. got:%T", stmt.Expression)
+		t.Fatalf("expression is not a valid *ast.Identifier type. got: %T instead", stmt.Expression)
 	}
 
 	if literal.Value != 5 {
-		t.Errorf("literal.Value not %d. got:%d", 5, literal.Value)
+		t.Errorf("literal.Value not %d. got: %d instead", 5, literal.Value)
 	}
 
 	if literal.TokenLiteral() != "5" {
-		t.Errorf("ident.TokenLiteral() not %s. got:%s", "foobar", literal.TokenLiteral())
+		t.Errorf("ident.TokenLiteral() not %s. got: %s instead", "foobar", literal.TokenLiteral())
 	}
 
 }
@@ -157,82 +158,86 @@ func TestParsePrefixExpressions(t *testing.T) {
 
 		if len(program.Statements) != 1 {
 
-			t.Fatalf("program.Statements expected to contain 1 statement. but got %d", len(program.Statements))
+			t.Fatalf("program.Statements expected to contain 1 statement. but got: %d instead", len(program.Statements))
 		}
 
 		stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
 		if !ok {
-			t.Fatalf("program.Statements[0] is not a valid *ast.ExpressionStatement type. got:%T", program.Statements[0])
+			t.Fatalf("program.Statements[0] is not a valid *ast.ExpressionStatement type. got: %T instead", program.Statements[0])
 		}
 
 		exp, ok := stmt.Expression.(*ast.PrefixExpression)
 		if !ok {
-			t.Fatalf("expression is not a valid *ast.PrefixExpression type. got:%T", stmt.Expression)
+			t.Fatalf("expression is not a valid *ast.PrefixExpression type. got: %T instead", stmt.Expression)
 		}
 
 		if exp.Operator != tc.operator {
-			t.Fatalf("exp.Operator is not '%s'. got:%s", tc.operator, exp.Operator)
+			t.Fatalf("exp.Operator is not '%s'. got: %s instead", tc.operator, exp.Operator)
 		}
 
-		// if !testIntegerLiteral(t, exp.Right, tc.integerValue) {
-		// 	return
-		// }
+		if !testIntegerLiteral(t, exp.Right, tc.integerValue) {
+			return
+		}
 	}
 }
 
 func TestParseInfixExpressions(t *testing.T) {
-	t.Skip()
-
 	tests := []struct {
-		input string
-		leftValue int64
-		operator string
-		rightValue int64 
+		input      string
+		leftValue  int64
+		operator   string
+		rightValue int64
 	}{
 		{
-			input: "2 + 1;",
+			input:      "2 + 1;",
 			leftValue:  2,
 			operator:   "+",
 			rightValue: 1,
 		},
 		{
-			input: "6 - 4;",
-			leftValue: 6,
+			input:      "6 - 4;",
+			leftValue:  6,
 			operator:   "-",
 			rightValue: 4,
 		},
 		{
-			input: "9 * 6;",
+			input:      "9 * 6;",
 			leftValue:  9,
 			operator:   "*",
 			rightValue: 6,
 		},
 		{
-			input: "9 / 6;",
+			input:      "9 / 6;",
 			leftValue:  9,
 			operator:   "/",
 			rightValue: 6,
 		},
 		{
-			input: "9 > 6;",
+			input:      "9 > 6;",
 			leftValue:  9,
 			operator:   ">",
 			rightValue: 6,
 		},
 		{
-			input: "9 * 6;",
+			input:      "9 < 6;",
 			leftValue:  9,
 			operator:   "<",
 			rightValue: 6,
 		},
 		{
-			input: "9 == 6;",
+			input:      "9 * 6;",
+			leftValue:  9,
+			operator:   "*",
+			rightValue: 6,
+		},
+		{
+			input:      "9 == 6;",
 			leftValue:  9,
 			operator:   "==",
 			rightValue: 6,
 		},
 		{
-			input: "9 != 6;",
+			input:      "9 != 6;",
 			leftValue:  9,
 			operator:   "!=",
 			rightValue: 6,
@@ -247,44 +252,151 @@ func TestParseInfixExpressions(t *testing.T) {
 		checkParserErrors(t, p)
 
 		if len(program.Statements) != 1 {
-			t.Fatalf("program.Statements expected to contain 1 statement. but got %d", len(program.Statements))
+			t.Fatalf("program.Statements expected to contain 1 statement. but got: %d instead", len(program.Statements))
 		}
 
-		// stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
-		// if !ok {
-		// 	t.Fatalf("program.Statements[0] is not a valid *ast.ExpressionStatement type. got:%T", program.Statements[0])
-		// }
+		stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+		if !ok {
+			t.Fatalf("program.Statements[0] is not a valid *ast.ExpressionStatement type. got: %T instead", program.Statements[0])
+		}
 
-		// exp, ok := stmt.(*ast.InfixExpression)
-		// if !ok {
-		// 	t.Fatalf("expression is not a valid *ast.InfixExpression type. got:%T", stmt.Expression)
-		// }	
+		exp, ok := stmt.Expression.(*ast.InfixExpression)
+		if !ok {
+			t.Fatalf("expression is not a valid *ast.InfixExpression type. got: %T instead", stmt.Expression)
+		}
+
+		if !testIntegerLiteral(t, exp.Left, tc.leftValue) {
+			return
+		}
+
+		if exp.Operator != tc.operator {
+			t.Errorf("exp.operator is not '%s', got: '%s' instead", tc.operator, exp.Operator)
+		}
+
+		if !testIntegerLiteral(t, exp.Right, tc.rightValue) {
+			return
+		}
 	}
 
 }
 
+func TestOperatorPrecedenceParsing(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "-a * b;",
+			expected: "((-a) * b)",
+		},
+		{
+			input:    "!-a;",
+			expected: "(!(-a))",
+		},
+		{
+			input:    "1 + 2 + 3;",
+			expected: "((1 + 2) + 3)",
+		},
+		{
+			input:    "a + b - c;",
+			expected: "((a + b) - c)",
+		},
+		{
+			input:    "a * b * c;",
+			expected: "((a * b) * c)",
+		},
+		{
+			input:    "a * b / c;",
+			expected: "((a * b) / c)",
+		},
+		{
+			input:    "a + b / c;",
+			expected: "(a + (b / c))",
+		},
+		{
+			input:    "a + b * c + d / e - f;",
+			expected: "(((a + (b * c)) + (d / e)) - f)",
+		},
+		{
+			input:    "3 + 4; -5 * 5;",
+			expected: "(3 + 4)((-5) * 5)",
+		},
+		{
+			input:    "5 > 4 == 3 < 4;",
+			expected: "((5 > 4) == (3 < 4))",
+		}, {
+			input:    "5 < 4 != 3 > 4;",
+			expected: "((5 < 4) != (3 > 4))",
+		},
+		{
+			input:    "3 + 4 * 5 == 3 * 1 + 4 * 5;",
+			expected: "((3 + (4 * 5)) == ((3 * 1) + (4 * 5)))",
+		}, {
+			input:    "3 + 4 * 5 == 3 * 1 + 4 * 5;",
+			expected: "((3 + (4 * 5)) == ((3 * 1) + (4 * 5)))",
+		},
+	}
+
+	for _, tc := range tests {
+		l := lexer.New(tc.input)
+		p := New(l)
+		program := p.ParseProgram()
+
+		checkParserErrors(t, p)
+
+		output := program.String()
+
+		if tc.expected != output {
+			t.Errorf("expected %s, got %s instead", tc.expected, output)
+		}
+	}
+}
+
 func testLetStatement(t *testing.T, s ast.Statement, name string) bool {
 	if s.TokenLiteral() != "let" {
-		t.Errorf("s.TokenLiteral() is not a 'let'. got:%q", s.TokenLiteral())
+		t.Errorf("s.TokenLiteral() is not a 'let'. got: %q instead", s.TokenLiteral())
 
 		return false
 	}
 
 	letSmt, ok := s.(*ast.LetStatement)
 	if !ok {
-		t.Errorf("s is not a valid *ast.LetStatement type. got:%T", s)
+		t.Errorf("s is not a valid *ast.LetStatement type. got: %T instead", s)
 
 		return false
 	}
 
 	if letSmt.Name.Value != name {
-		t.Errorf("letSmt.Name.Value is not '%s'. got:%s", name, letSmt.Name.Value)
+		t.Errorf("letSmt.Name.Value is not '%s'. got: %s instead", name, letSmt.Name.Value)
 
 		return false
 	}
 
 	if letSmt.Name.TokenLiteral() != name {
-		t.Errorf("s.Name is not '%s'. got:%s", name, letSmt.Name.Value)
+		t.Errorf("s.Name is not '%s'. got: %s instead", name, letSmt.Name.Value)
+
+		return false
+	}
+
+	return true
+}
+
+func testIntegerLiteral(t *testing.T, il ast.Expression, value int64) bool {
+	intLit, ok := il.(*ast.IntegerLiteral)
+	if !ok {
+		t.Errorf("il is not *ast.IntegerLiteral. got: %T instead", il)
+
+		return false
+	}
+
+	if intLit.Value != value {
+		t.Errorf("intV.Value is not %d. got: %d instead", value, intLit.Value)
+
+		return false
+	}
+
+	if intLit.TokenLiteral() != fmt.Sprintf("%d", value) {
+		t.Errorf("intV.TokenLiteral() is not %d. got: %s instead", value, intLit.TokenLiteral())
 
 		return false
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/mycok/monkey_interpreter/ast"
@@ -17,8 +16,8 @@ func TestParseLetStatements(t *testing.T) {
 
 	l := lexer.New(input)
 	p := New(l)
-
 	program := p.ParseProgram()
+
 	checkParserErrors(t, p)
 
 	if len(program.Statements) != 3 {
@@ -50,8 +49,8 @@ func TestParseReturnStatements(t *testing.T) {
 	`
 	l := lexer.New(input)
 	p := New(l)
-
 	program := p.ParseProgram()
+
 	checkParserErrors(t, p)
 
 	if len(program.Statements) != 3 {
@@ -60,6 +59,7 @@ func TestParseReturnStatements(t *testing.T) {
 
 	for _, stmt := range program.Statements {
 		returnStmt, ok := stmt.(*ast.ReturnStatement)
+
 		if !ok {
 			t.Errorf("stmt is not of a valid *ast.ReturnStatement type. got:%T", stmt)
 			continue
@@ -77,6 +77,7 @@ func TestParseIdentifierExpressions(t *testing.T) {
 	l := lexer.New(input)
 	p := New(l)
 	program := p.ParseProgram()
+
 	checkParserErrors(t, p)
 
 	if len(program.Statements) != 1 {
@@ -109,10 +110,11 @@ func TestParseIntegerLiteralExpressions(t *testing.T) {
 	l := lexer.New(input)
 	p := New(l)
 	program := p.ParseProgram()
+
 	checkParserErrors(t, p)
 
 	if len(program.Statements) != 1 {
-		t.Fatalf("program.Statements expected to contain 1 statement. but got %d", len(program.Statements))
+		t.Fatalf("program.Statement expected to contain 1 statement. but got %d", len(program.Statements))
 	}
 
 	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
@@ -149,12 +151,13 @@ func TestParsePrefixExpressions(t *testing.T) {
 	for _, tc := range tests {
 		l := lexer.New(tc.input)
 		p := New(l)
-
 		program := p.ParseProgram()
+
 		checkParserErrors(t, p)
 
 		if len(program.Statements) != 1 {
-			t.Fatalf("program.Statements expected to contain 1 statements. but got %d", len(program.Statements))
+
+			t.Fatalf("program.Statements expected to contain 1 statement. but got %d", len(program.Statements))
 		}
 
 		stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
@@ -171,33 +174,93 @@ func TestParsePrefixExpressions(t *testing.T) {
 			t.Fatalf("exp.Operator is not '%s'. got:%s", tc.operator, exp.Operator)
 		}
 
-		if !testIntegerLiteral(t, exp.Right, tc.integerValue) {
-			return
-		}
+		// if !testIntegerLiteral(t, exp.Right, tc.integerValue) {
+		// 	return
+		// }
 	}
 }
 
-func testIntegerLiteral(t *testing.T, il ast.Expression, value int64) bool {
-	intV, ok := il.(*ast.IntegerLiteral)
-	if !ok {
-		t.Errorf("il is not *ast.IntegerLiteral. got:%T", il)
+func TestParseInfixExpressions(t *testing.T) {
+	t.Skip()
 
-		return false
+	tests := []struct {
+		input string
+		leftValue int64
+		operator string
+		rightValue int64 
+	}{
+		{
+			input: "2 + 1;",
+			leftValue:  2,
+			operator:   "+",
+			rightValue: 1,
+		},
+		{
+			input: "6 - 4;",
+			leftValue: 6,
+			operator:   "-",
+			rightValue: 4,
+		},
+		{
+			input: "9 * 6;",
+			leftValue:  9,
+			operator:   "*",
+			rightValue: 6,
+		},
+		{
+			input: "9 / 6;",
+			leftValue:  9,
+			operator:   "/",
+			rightValue: 6,
+		},
+		{
+			input: "9 > 6;",
+			leftValue:  9,
+			operator:   ">",
+			rightValue: 6,
+		},
+		{
+			input: "9 * 6;",
+			leftValue:  9,
+			operator:   "<",
+			rightValue: 6,
+		},
+		{
+			input: "9 == 6;",
+			leftValue:  9,
+			operator:   "==",
+			rightValue: 6,
+		},
+		{
+			input: "9 != 6;",
+			leftValue:  9,
+			operator:   "!=",
+			rightValue: 6,
+		},
 	}
 
-	if intV.Value != value {
-		t.Errorf("intV.Value is not %d. got:%d", value, intV.Value)
+	for _, tc := range tests {
+		l := lexer.New(tc.input)
+		p := New(l)
+		program := p.ParseProgram()
 
-		return false
+		checkParserErrors(t, p)
+
+		if len(program.Statements) != 1 {
+			t.Fatalf("program.Statements expected to contain 1 statement. but got %d", len(program.Statements))
+		}
+
+		// stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+		// if !ok {
+		// 	t.Fatalf("program.Statements[0] is not a valid *ast.ExpressionStatement type. got:%T", program.Statements[0])
+		// }
+
+		// exp, ok := stmt.(*ast.InfixExpression)
+		// if !ok {
+		// 	t.Fatalf("expression is not a valid *ast.InfixExpression type. got:%T", stmt.Expression)
+		// }	
 	}
 
-	if intV.TokenLiteral() != fmt.Sprintf("%d", value) {
-		t.Errorf("intV.TokenLiteral() is not %d. got:%s", value, intV.TokenLiteral())
-
-		return false
-	}
-
-	return true
 }
 
 func testLetStatement(t *testing.T, s ast.Statement, name string) bool {

--- a/token/token.go
+++ b/token/token.go
@@ -5,13 +5,13 @@ const (
 	ILLEGAL = "ILLEGAL"
 
 	// EOF represents end of file.
-	EOF     = "EOF"
+	EOF = "EOF"
 
 	// IDENT such as add, foobar, x,y, ....etc
 	IDENT = "IDENT"
 
 	// INT such as 1234567890
-	INT   = "INT"
+	INT = "INT"
 
 	// ASSIGN ... are some of the operators implemented in the language.
 	ASSIGN   = "="


### PR DESCRIPTION
- update parseExpression method to add functionality for parsing infix operators [1 + 2;, 1 + 2 + 3;]
- add parseInfixExpression parsing method
- add precedence constants for operator tokens
- add unit tests for infix operator parsing functionality